### PR TITLE
9 curl input bug

### DIFF
--- a/src/CurlParameters.php
+++ b/src/CurlParameters.php
@@ -60,6 +60,13 @@ class CurlParameters implements CurlParametersInterface
   protected $followRedirects = false;
 
   /**
+   * The proxy data.
+   *
+   * @var string
+   */
+  protected $proxy;
+
+  /**
    * {@inheritdoc}
    */
   public function getUrl(): ?string
@@ -90,6 +97,15 @@ class CurlParameters implements CurlParametersInterface
   public function setHeaders(array $headers): CurlParametersInterface
   {
     $this->headers = $headers;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addHeader(string $header): CurlParametersInterface
+  {
+    $this->headers[] = $header;
     return $this;
   }
 
@@ -216,4 +232,22 @@ class CurlParameters implements CurlParametersInterface
   {
     return $this->followRedirects;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProxy()
+  {
+    return $this->proxy;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setProxy(string $proxy): CurlParametersInterface
+  {
+    $this->proxy = $proxy;
+    return $this;
+  }
+
 }

--- a/src/CurlParametersInterface.php
+++ b/src/CurlParametersInterface.php
@@ -25,6 +25,7 @@ interface CurlParametersInterface {
    *   The URL.
    *
    * @return CurlParametersInterface
+   *   The current object.
    */
   public function setUrl(string $url): CurlParametersInterface;
 
@@ -43,8 +44,20 @@ interface CurlParametersInterface {
    *   The headers to set.
    *
    * @return CurlParametersInterface
+   *   The current object.
    */
   public function setHeaders(array $headers): CurlParametersInterface;
+
+  /**
+   * Add a header to the header list.
+   *
+   * @param string $header
+   *   The header to add.
+   *
+   * @return CurlParametersInterface
+   *   The current object.
+   */
+  public function addHeader(string $header): CurlParametersInterface;
 
   /**
    * Get the data payload of the request.
@@ -171,4 +184,23 @@ interface CurlParametersInterface {
    *   True if redirects are to be followed.
    */
   public function followRedirects() : bool;
+
+  /**
+   * Get the proxy value.
+   *
+   * @return mixed
+   *   The proxy value.
+   */
+  public function getProxy();
+
+  /**
+   * Set the proxy value.
+   *
+   * @param mixed $proxy
+   *   The proxy value.
+   *
+   * @return CurlParametersInterface
+   *   The current object.
+   */
+  public function setProxy(string $proxy): CurlParametersInterface;
 }

--- a/src/Input/CurlInput.php
+++ b/src/Input/CurlInput.php
@@ -24,45 +24,112 @@ class CurlInput implements InputInterface
       die('not a curl command');
     }
 
-    $headers = [];
-
     $curlParameters = new CurlParameters();
 
-    // Remove the curl command from the front.
-    $data = substr(trim($data), 5);
+    // Remove the "curl" command part from the front.
+    $data = substr(trim($data), 4);
+    $data = str_replace(" \\\n", '', $data);
 
-    // Match parameters.
-    $regex = '';
-    $regex .= '(-[a-zA-Z\-]+? \'?.*[\s]\'?)|'; // Single letter flags with values.
-    $regex .= '(--[a-zA-Z\-]+ \'?.*\'?[\s]?)|'; // Multi letter flags with values.
-    $regex .= '("?[a-z]+:\/\/.*?"+?)|'; // Address matching with double quotes.
-    $regex .= '(\'?[a-z]+:\/\/.*?\'+?)|'; // Address matching with single quotes.
-    $regex .= '(--[a-zA-Z\-]+)|'; // Multi letter flags with no value.
-    $regex .= '(-[a-aA-Z]+)'; // Single letter flags with no value.
-    preg_match_all('/' . $regex . '/', $data, $parameters);
+    $splitCommand = array_filter(preg_split('/\s--?/U', $data));
 
-    $parameters = $parameters[0];
-    $parameterCount = count($parameters);
-    for ($i = 0; $i < $parameterCount; ++$i) {
-      if (preg_match('/(?:--?)([A-Za-z\-]+)(?:\s?)(.*)?/', $parameters[$i], $flagMatch) === 1) {
-        $flag = $flagMatch[1];
-        $contents = trim($flagMatch[2]);
-        switch ($flag) {
-          case 'url':
-            $curlParameters->setUrl($contents);
+    foreach ($splitCommand as $flag) {
+      // If a '-' is present in the first character then remove it.
+      if (substr_compare($flag, '-', 0, 1) === 0) {
+        $flag = substr($flag, 1);
+      }
+
+      $flag = trim($flag);
+
+      if (strpos($flag, ' ') === false) {
+        // If the flag contains no strings it is a single flag.
+        switch (strtolower($flag)) {
+          case 'insecure':
+            $curlParameters->setIsInsecure(true);
+            $data = str_replace($flag, '', $data);
             break;
+          case 'L':
+            $curlParameters->setFollowRedirects(true);
+            $data = str_replace($flag, '', $data);
+            break;
+        }
+        continue;
+      }
+
+      // Simple flag with a single, unquoted, parameter.
+      $explodedFlag = explode(' ', $flag);
+      if ($explodedFlag[0] !== '') {
+        switch ($explodedFlag[0]) {
+          case 'u':
+          case 'user':
+            $credentials = explode(':', $explodedFlag[1]);
+            $curlParameters->setUsername($credentials[0]);
+            $curlParameters->setPassword($credentials[1]);
+            $data = str_replace($explodedFlag[0] . ' ' . $explodedFlag[1], '', $data);
+            break;
+          case 'X':
+          case 'request':
+            $curlParameters->setHttpVerb(strtoupper($explodedFlag[1]));
+            $data = str_replace($explodedFlag[0] . ' ' . $explodedFlag[1], '', $data);
+            break;
+          case 'url':
+            $curlParameters->setUrl($explodedFlag[1]);
+            $data = str_replace($explodedFlag[0] . ' ' . $explodedFlag[1], '', $data);
+            break;
+          case 'proxy':
+            $curlParameters->setProxy($explodedFlag[1]);
+            $data = str_replace($explodedFlag[0] . ' ' . $explodedFlag[1], '', $data);
+            break;
+        }
+
+        if (preg_match('/X(.*)/', $explodedFlag[0], $httpVerb) === 1) {
+          if ($httpVerb[1] !== '') {
+            $curlParameters->setHttpVerb(strtoupper($httpVerb[1]));
+            $data = str_replace($httpVerb[0], '', $data);
+          }
+          $explodedFlag[0] = str_replace($httpVerb[0], '', $explodedFlag[0]);
+        }
+
+        foreach (str_split($explodedFlag[0]) as $arg) {
+          switch ($arg) {
+            case 's':
+              // Silent.
+              $data = str_replace($explodedFlag[0], '', $data);
+              break;
+            case 'S':
+              // Show error.
+              $data = str_replace($explodedFlag[0], '', $data);
+              break;
+            case 'L':
+              // Location.
+              $curlParameters->setFollowRedirects(true);
+              $data = str_replace($explodedFlag[0], '', $data);
+              break;
+            case 'I':
+              // Head.
+              if ($curlParameters->getHttpVerb() === 'GET') {
+                $curlParameters->setHttpVerb('HEAD');
+              }
+              $data = str_replace($explodedFlag[0], '', $data);
+            break;
+          }
+        }
+      }
+
+      if (substr_compare($flag, '"', -1) === 0) {
+        // Flag contents has double quotes.
+        preg_match('/"([^"]+)\"/U', $flag, $flagContents);
+        $flagKey = trim(str_replace($flagContents[0], '', $flag));
+        $flagContents = $flagContents[1];
+        switch ($flagKey) {
           case 'H':
           case 'header':
           case 'headers':
-            $contents = trim(str_replace(["'", '\\'], '', $contents));
-            $headers[] = $contents;
-            break;
-          case 'X':
-            $curlParameters->setHttpVerb(strtoupper($contents));
+            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
+            $curlParameters->addHeader($contents);
             break;
           case 'u':
           case 'user':
-            $credentials = explode(':', $contents);
+            $credentials = explode(':', $flagContents);
             $curlParameters->setUsername($credentials[0]);
             $curlParameters->setPassword($credentials[1]);
             break;
@@ -72,22 +139,67 @@ class CurlInput implements InputInterface
           case 'data-raw':
           case 'data-urlencode':
           case 'data-binary':
-            $curlParameters->setHttpVerb('POST');
-            $contents = trim(str_replace(["'", '\\'], '', $contents));
+            if ($curlParameters->getHttpVerb() === 'GET') {
+              $curlParameters->setHttpVerb('POST');
+            }
+            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
             $curlParameters->setData($contents);
             break;
-          case 'insecure':
-            $curlParameters->setIsInsecure(true);
+          case 'proxy':
+            $curlParameters->setProxy($flagContents);
             break;
-          case 'L':
-            $curlParameters->setFollowRedirects(true);
+          case 'url':
+            $curlParameters->setUrl($flagContents);
             break;
         }
+        $data = str_replace($flagKey . ' "' . $flagContents . '"', '', $data);
+        continue;
+      }
+
+      if (substr_compare($flag, '\'', -1) === 0) {
+        // Flag contents has single quotes.
+        preg_match('/\'([^\']+)\'/U', $flag, $flagContents);
+        $flagKey = trim(str_replace($flagContents[0], '', $flag));
+        $flagContents = $flagContents[1];
+        switch ($flagKey) {
+          case 'H':
+          case 'header':
+          case 'headers':
+            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
+            $curlParameters->addHeader($contents);
+            break;
+          case 'u':
+          case 'user':
+            $credentials = explode(':', $flagContents);
+            $curlParameters->setUsername($credentials[0]);
+            $curlParameters->setPassword($credentials[1]);
+            break;
+          case 'data':
+          case 'data-ascii':
+          case 'd':
+          case 'data-raw':
+          case 'data-urlencode':
+          case 'data-binary':
+            if ($curlParameters->getHttpVerb() === 'GET') {
+              $curlParameters->setHttpVerb('POST');
+            }
+            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
+            $curlParameters->setData($contents);
+            break;
+          case 'proxy':
+            $curlParameters->setProxy($flagContents);
+            break;
+          case 'url':
+            $curlParameters->setUrl($flagContents);
+            break;
+        }
+        $data = str_replace($flagKey . ' \'' . $flagContents . '\'', '', $data);
       }
     }
 
     if (empty($curlParameters->getUrl())) {
       // Find url.
+      $data = trim($data);
       preg_match_all('/(?:[\'|"]?)https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)(?:[\'|"]?)/im', $data, $url);
 
       if (isset($url[0])) {
@@ -95,8 +207,6 @@ class CurlInput implements InputInterface
         $curlParameters->setUrl($url);
       }
     }
-
-    $curlParameters->setHeaders($headers);
 
     return $curlParameters;
   }

--- a/src/Input/CurlInput.php
+++ b/src/Input/CurlInput.php
@@ -37,7 +37,6 @@ class CurlInput implements InputInterface
       if (substr_compare($flag, '-', 0, 1) === 0) {
         $flag = substr($flag, 1);
       }
-
       $flag = trim($flag);
 
       if (strpos($flag, ' ') === false) {
@@ -120,38 +119,9 @@ class CurlInput implements InputInterface
         preg_match('/"([^"]+)\"/U', $flag, $flagContents);
         $flagKey = trim(str_replace($flagContents[0], '', $flag));
         $flagContents = $flagContents[1];
-        switch ($flagKey) {
-          case 'H':
-          case 'header':
-          case 'headers':
-            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
-            $curlParameters->addHeader($contents);
-            break;
-          case 'u':
-          case 'user':
-            $credentials = explode(':', $flagContents);
-            $curlParameters->setUsername($credentials[0]);
-            $curlParameters->setPassword($credentials[1]);
-            break;
-          case 'data':
-          case 'data-ascii':
-          case 'd':
-          case 'data-raw':
-          case 'data-urlencode':
-          case 'data-binary':
-            if ($curlParameters->getHttpVerb() === 'GET') {
-              $curlParameters->setHttpVerb('POST');
-            }
-            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
-            $curlParameters->setData($contents);
-            break;
-          case 'proxy':
-            $curlParameters->setProxy($flagContents);
-            break;
-          case 'url':
-            $curlParameters->setUrl($flagContents);
-            break;
-        }
+
+        $this->extractQuotedParams($curlParameters, $flagKey, $flagContents);
+
         $data = str_replace($flagKey . ' "' . $flagContents . '"', '', $data);
         continue;
       }
@@ -161,38 +131,9 @@ class CurlInput implements InputInterface
         preg_match('/\'([^\']+)\'/U', $flag, $flagContents);
         $flagKey = trim(str_replace($flagContents[0], '', $flag));
         $flagContents = $flagContents[1];
-        switch ($flagKey) {
-          case 'H':
-          case 'header':
-          case 'headers':
-            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
-            $curlParameters->addHeader($contents);
-            break;
-          case 'u':
-          case 'user':
-            $credentials = explode(':', $flagContents);
-            $curlParameters->setUsername($credentials[0]);
-            $curlParameters->setPassword($credentials[1]);
-            break;
-          case 'data':
-          case 'data-ascii':
-          case 'd':
-          case 'data-raw':
-          case 'data-urlencode':
-          case 'data-binary':
-            if ($curlParameters->getHttpVerb() === 'GET') {
-              $curlParameters->setHttpVerb('POST');
-            }
-            $contents = trim(str_replace(["'", '\\'], '', $flagContents));
-            $curlParameters->setData($contents);
-            break;
-          case 'proxy':
-            $curlParameters->setProxy($flagContents);
-            break;
-          case 'url':
-            $curlParameters->setUrl($flagContents);
-            break;
-        }
+
+        $this->extractQuotedParams($curlParameters, $flagKey, $flagContents);
+
         $data = str_replace($flagKey . ' \'' . $flagContents . '\'', '', $data);
       }
     }
@@ -209,6 +150,49 @@ class CurlInput implements InputInterface
     }
 
     return $curlParameters;
+  }
+
+  /**
+   * Extract the arguments from a quoted parameter.
+   *
+   * @param CurlParametersInterface $curlParameters
+   *   The current object that implements CurlParametersInterface.
+   * @param string $flagKey
+   *   The flag key.
+   * @param string $flagContents
+   *   The flag contents.
+   */
+  protected function extractQuotedParams($curlParameters, $flagKey, $flagContents) {
+    switch ($flagKey) {
+      case 'H':
+      case 'header':
+      case 'headers':
+        $curlParameters->addHeader($flagContents);
+        break;
+      case 'u':
+      case 'user':
+        $credentials = explode(':', $flagContents);
+        $curlParameters->setUsername($credentials[0]);
+        $curlParameters->setPassword($credentials[1]);
+        break;
+      case 'data':
+      case 'data-ascii':
+      case 'd':
+      case 'data-raw':
+      case 'data-urlencode':
+      case 'data-binary':
+        if ($curlParameters->getHttpVerb() === 'GET') {
+          $curlParameters->setHttpVerb('POST');
+        }
+        $curlParameters->setData($flagContents);
+        break;
+      case 'proxy':
+        $curlParameters->setProxy($flagContents);
+        break;
+      case 'url':
+        $curlParameters->setUrl($flagContents);
+        break;
+    }
   }
 
 }

--- a/src/Input/CurlInput.php
+++ b/src/Input/CurlInput.php
@@ -20,8 +20,7 @@ class CurlInput implements InputInterface
   {
     $data = trim($data);
     if (strpos($data, 'curl ') !== 0) {
-      // @todo : refactor this into a method and a throwable error
-      die('not a curl command');
+      throw new \InvalidArgumentException('Not a CURL command.');
     }
 
     $curlParameters = new CurlParameters();

--- a/test/Input/CurlInputTest.php
+++ b/test/Input/CurlInputTest.php
@@ -7,6 +7,14 @@ use Hashbangcode\CurlConverter\Input\CurlInput;
 
 class CurlInputTest extends TestCase
 {
+  public function testBrokenCurlCommand()
+  {
+    $this->expectException('InvalidArgumentException');
+    $notCurlString = 'monkey https://www.example.com';
+    $input = new CurlInput();
+    $curlParameters = $input->extract($notCurlString);
+  }
+
   public function testCurlInputWithSimpleCommand()
   {
     $curlString = "curl https://www.example.com/";
@@ -167,6 +175,8 @@ EOD;
     $this->assertEquals('username', $curlParameters->getUsername());
     $this->assertEquals('password', $curlParameters->getPassword());
     $this->assertEquals('POST', $curlParameters->getHttpVerb());
+    $this->assertEquals('Content-Type: application/json', $curlParameters->getHeaders()[0]);
+    $this->assertEquals('{"key1":"value1", "key2":"value2"}', $curlParameters->getData());
     $this->assertEquals('http://proxy.example.com:8080', $curlParameters->getProxy());
     $this->assertEquals('https://example.com/api/resource', $curlParameters->getUrl());
   }


### PR DESCRIPTION
Changes:
- Made the extract method throw an exception if a non curl string is passed to it.
- Refactored the CurlInput::extract function to have less duplicated code.
- Reworked how the curl commands are parsed. Also added proxy to the list of flags that are detected. Allowed headers to be added individually. Added a couple of edge cases to the test suite.